### PR TITLE
Create UpdateArticle API

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -72,6 +72,55 @@ var doc = `{
                 }
             }
         },
+        "/http/v1/articles/:id": {
+            "put": {
+                "description": "UpdateArticle updates an existing article.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Articles"
+                ],
+                "summary": "Update article.",
+                "parameters": [
+                    {
+                        "description": "Article ingredient",
+                        "name": "article",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.Article"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Article"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/http/v1/articles/{id}": {
             "get": {
                 "description": "GetArticle finds and returns one Article by request ID.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -56,6 +56,55 @@
                 }
             }
         },
+        "/http/v1/articles/:id": {
+            "put": {
+                "description": "UpdateArticle updates an existing article.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Articles"
+                ],
+                "summary": "Update article.",
+                "parameters": [
+                    {
+                        "description": "Article ingredient",
+                        "name": "article",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.Article"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Article"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/http/v1/articles/{id}": {
             "get": {
                 "description": "GetArticle finds and returns one Article by request ID.",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -69,6 +69,38 @@ paths:
       summary: Create new article.
       tags:
       - Articles
+  /http/v1/articles/:id:
+    put:
+      description: UpdateArticle updates an existing article.
+      parameters:
+      - description: Article ingredient
+        in: body
+        name: article
+        required: true
+        schema:
+          $ref: '#/definitions/api.Article'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.Article'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/http.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/http.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/http.ErrorResponse'
+      summary: Update article.
+      tags:
+      - Articles
   /http/v1/articles/{id}:
     get:
       description: GetArticle finds and returns one Article by request ID.

--- a/internal/app/article/application/handlers.go
+++ b/internal/app/article/application/handlers.go
@@ -9,6 +9,7 @@ import (
 type Handler interface {
 	GetArticleByID(id string) (*domain.Article, error)
 	CreateArticle(title, author, source, body string, status int) (*domain.Article, error)
+	UpdateArticle(id, title, author, source, body string, status int) (*domain.Article, error)
 }
 
 type articleHandler struct {
@@ -33,6 +34,25 @@ func (h *articleHandler) CreateArticle(title, author, source, body string, statu
 	}
 
 	return &article, nil
+}
+
+func (h *articleHandler) UpdateArticle(id, title, author, source, body string, status int) (*domain.Article, error) {
+	article, err := h.repo.GetArticleByID(id)
+	if err != nil {
+		return nil, fmt.Errorf("[application.articleHandler.UpdateArticle()] err: %w", err)
+	}
+
+	err = article.Update(title, author, source, body, status)
+	if err != nil {
+		return nil, fmt.Errorf("[application.articleHandler.UpdateArticle()] err: %w", err)
+	}
+
+	err = h.repo.SaveArticle(article)
+	if err != nil {
+		return nil, fmt.Errorf("[application.articleHandler.UpdateArticle()] err: %w", err)
+	}
+
+	return article, nil
 }
 
 func NewArticleHandler(repository domain.ArticleRepository) Handler {

--- a/internal/app/article/domain/entities.go
+++ b/internal/app/article/domain/entities.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -43,6 +44,18 @@ func (a *Article) Status() int {
 	return a.status
 }
 
+func (a *Article) setStatus(status int) error {
+	if status != statusDraft && status != statusPublished {
+		return fmt.Errorf("[domain.Article.setStatus()] err: %w", InvalidStatusError)
+	}
+	if a.isPublished() && status == statusDraft {
+		return fmt.Errorf("[domain.Article.setStatus()] err: %w", AlreadyPublishedError)
+	}
+	a.status = status
+
+	return nil
+}
+
 func (a *Article) PublishedDate() *time.Time {
 	return a.publishedDate
 }
@@ -52,6 +65,24 @@ func (a *Article) GenerateID() {
 		id, _ := uuid.NewUUID()
 		a.id = id.String()
 	}
+}
+
+func (a *Article) isPublished() bool {
+	return a.status == statusPublished
+}
+
+func (a *Article) Update(newTitle, newAuthor, newSource, newBody string, newStatus int) error {
+	a.title = newTitle
+	a.author = newAuthor
+	a.source = newSource
+	a.body = newBody
+
+	err := a.setStatus(newStatus)
+	if err != nil {
+		return fmt.Errorf("[domain.Article.Update()] err: %w", err)
+	}
+
+	return nil
 }
 
 func NewArticle(id, title, author, source, body string, status int) Article {

--- a/internal/app/article/domain/errors.go
+++ b/internal/app/article/domain/errors.go
@@ -1,0 +1,8 @@
+package domain
+
+import "errors"
+
+var (
+	InvalidStatusError = errors.New("invalid status error")
+	AlreadyPublishedError = errors.New("published article cannot be changed back to a draft")
+)

--- a/internal/app/article/domain/values.go
+++ b/internal/app/article/domain/values.go
@@ -1,0 +1,6 @@
+package domain
+
+const (
+	statusDraft = iota
+	statusPublished
+)

--- a/internal/app/article/presentation/api/controllers.go
+++ b/internal/app/article/presentation/api/controllers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"api-server/internal/app/article/application"
+	"api-server/internal/app/article/domain"
 	"api-server/internal/app/article/infrastructure/persistence"
 	httppkg "api-server/internal/pkg/http"
 )
@@ -67,9 +68,34 @@ func (con *ArticleController) PostArticle(c echo.Context) error {
 	return c.JSON(http.StatusCreated, MapArticleResponse(res))
 }
 
+// UpdateArticle godoc
+// @Summary      Update article.
+// @Description  UpdateArticle updates an existing article.
+// @Tags         Articles
+// @Param        article   body Article true  "Article ingredient"
+// @Produce      json
+// @Success      200  {object}  Article
+// @Failure      400  {object}  http.ErrorResponse
+// @Failure      404  {object}  http.ErrorResponse
+// @Failure      500  {object}  http.ErrorResponse
+// @Router       /http/v1/articles/:id [put]
+func (con *ArticleController) UpdateArticle(c echo.Context) error {
+	article := new(Article)
+	if err := con.Bind(c, article); err != nil {
+		return con.handleErrorResponse(c, err)
+	}
+
+	res, err := con.handler.UpdateArticle(article.ID, article.Title, article.Author, article.Source, article.Body, article.Status)
+	if err != nil {
+		return con.handleErrorResponse(c, err)
+	}
+
+	return c.JSON(http.StatusOK, MapArticleResponse(res))
+}
+
 func (con *ArticleController) handleErrorResponse(c echo.Context, err error) error {
 	switch {
-	case errors.Is(err, httppkg.InvalidRequestError):
+	case errors.Is(err, httppkg.InvalidRequestError), errors.Is(err, domain.AlreadyPublishedError):
 		return c.JSON(http.StatusBadRequest, httppkg.NewErrorResponse(InvalidRequest, "invalid request.", err.Error()))
 	case errors.Is(err, persistence.NotFoundError):
 		return c.JSON(http.StatusNotFound, httppkg.NewErrorResponse(NotFound, "resource not found.", err.Error()))

--- a/internal/pkg/server/routers.go
+++ b/internal/pkg/server/routers.go
@@ -18,6 +18,7 @@ func registerV1APIRoutes(router *echo.Echo, articleController *article.ArticleCo
 	{
 		v1.POST("/articles", articleController.PostArticle)
 		v1.GET("/articles/:id", articleController.GetArticle)
+		v1.PUT("/articles/:id", articleController.UpdateArticle)
 	}
 }
 


### PR DESCRIPTION
## As-is

## To-be
Article Update API를 구현 및 Status 값을 명시했습니다.

코드흐름
- controller-> handler-> domain <- repository

## Not to-be
계층간 데이터를 원시타입으로 주다보니, 파라미터가 많아져 코드가 더러워진 느낌이 있습니다. 다른 PR에서 별도의 DTO를 통해 파라미터를 줄이는 작업을 할까 합니다. 

## CheckList
[Code Review Guide](https://soojin.ro/review/)
- [x] 테스트 코드를 작성했습니다.
- [x] Self review를 진행했습니다.
- [ ] PR의 변경사항은 독립적인 한 가지입니다.
